### PR TITLE
Change to Caja URL and replacement of deprecated function.

### DIFF
--- a/mate-file-manager/src/caja-window-menus.c
+++ b/mate-file-manager/src/caja-window-menus.c
@@ -573,7 +573,7 @@ action_caja_manual_callback (GtkAction *action,
 	window = CAJA_WINDOW (user_data);
 
 	if (CAJA_IS_DESKTOP_WINDOW (window)) {
-	    	g_spawn_command_line_async("mate-help", &error);
+		g_spawn_command_line_async("mate-help", &error);
 	} else {
 		gtk_show_uri (gtk_window_get_screen (GTK_WINDOW (window)),
 			      "ghelp:user-guide#goscaja-1",

--- a/mate-file-manager/src/caja-window-menus.c
+++ b/mate-file-manager/src/caja-window-menus.c
@@ -545,8 +545,8 @@ action_about_caja_callback (GtkAction *action,
 				 */
 			      "translator-credits", _("translator-credits"),
 			      "logo-icon-name", "caja",
-			      "website", "https://github.com/Perberos/Mate-Desktop-Environment/"
-				  "wiki/Mate-file-manager",
+			      "website", "https://github.com/Perberos/Mate-Desktop-Environment"
+			      "/wiki/Mate-file-manager",
 			      "website-label", _("Caja Web Site"),
 			      NULL);
 
@@ -573,9 +573,7 @@ action_caja_manual_callback (GtkAction *action,
 	window = CAJA_WINDOW (user_data);
 
 	if (CAJA_IS_DESKTOP_WINDOW (window)) {
-		gdk_spawn_command_line_on_screen (
-			gtk_window_get_screen (GTK_WINDOW (window)),
-			"mate-help", &error);
+	    	g_spawn_command_line_async("mate-help", &error);
 	} else {
 		gtk_show_uri (gtk_window_get_screen (GTK_WINDOW (window)),
 			      "ghelp:user-guide#goscaja-1",

--- a/mate-file-manager/src/caja-window-menus.c
+++ b/mate-file-manager/src/caja-window-menus.c
@@ -545,7 +545,8 @@ action_about_caja_callback (GtkAction *action,
 				 */
 			      "translator-credits", _("translator-credits"),
 			      "logo-icon-name", "caja",
-			      "website", "http://live.mate.org/Caja",
+			      "website", "https://github.com/Perberos/Mate-Desktop-Environment/"
+				  "wiki/Mate-file-manager",
 			      "website-label", _("Caja Web Site"),
 			      NULL);
 


### PR DESCRIPTION
The "About Caja" window had a link to live.mate.org/Caja, which doesn't exit. I've set the link to now navigate to the wiki page for Caja.

I've also removed a deprecated function that was removed as of 2.24 and replaced it with a function that is valid for with both GTK2 and GTK3.

info here: http://developer.gnome.org/gdk/stable/GdkScreen.html#gdk-spawn-command-line-on-screen
