### PR TITLE
Fixed build issue with mate-notification-daemon

### DIFF
--- a/mate-notification-daemon/po/POTFILES.in
+++ b/mate-notification-daemon/po/POTFILES.in
@@ -1,6 +1,6 @@
 data/mate-notification-daemon.schemas.in
-src/capplet/notification-properties.c
-src/capplet/notification-properties.desktop.in
-[type: gettext/glade]src/capplet/notification-properties.ui
+src/capplet/mate-notification-properties.c
+src/capplet/mate-notification-properties.desktop.in
+[type: gettext/glade]src/capplet/mate-notification-properties.ui
 src/daemon/daemon.c
 src/daemon/sound.c

--- a/mate-notification-daemon/po/cs.po
+++ b/mate-notification-daemon/po/cs.po
@@ -58,32 +58,32 @@ msgstr "Motiv používaný k zobrazování oznámení."
 msgid "Turns on and off sound support for notifications."
 msgstr "Zapne a vypne zvukovou podporu u oznámení."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Táhlo"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Standardní motiv"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Chyba během spouštění libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Text oznámení"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Toliko test"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Chyba při zobrazování oznámení: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Nelze načíst soubor rozložení uživatelského rozhraní: %s"

--- a/mate-notification-daemon/po/da.po
+++ b/mate-notification-daemon/po/da.po
@@ -57,32 +57,32 @@ msgstr "Temaet brugt under visning af påmindelser."
 msgid "Turns on and off sound support for notifications."
 msgstr "Slår lydunderstøttelse af påmindelser til/fra."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Rullebjælke"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Standardtema"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Kunne ikke initialisere libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Påmindelsestest"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Bare en test"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Kunne ikke vise påmindelse: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Kunne ikke indlæse brugergrænsefladefil: %s"

--- a/mate-notification-daemon/po/de.po
+++ b/mate-notification-daemon/po/de.po
@@ -58,32 +58,32 @@ msgstr "Das Thema um Benachrichtigungen anzuzeigen."
 msgid "Turns on and off sound support for notifications."
 msgstr "Schaltet Klänge für Benachrichtigungen ein oder aus."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Schieber"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Standardthema"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Fehler beim Initialisieren von libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Test für Benachrichtigungen"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Nur ein Test"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Fehler bei der Anzeige der Benachrichtigung: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Benutzerschnittstellendatei konnte nicht geladen werden: %s"

--- a/mate-notification-daemon/po/el.po
+++ b/mate-notification-daemon/po/el.po
@@ -61,32 +61,32 @@ msgstr "Το θέμα που χρησιμοποιείται κατά την εμ
 msgid "Turns on and off sound support for notifications."
 msgstr "Ενεργοποιεί ή απενεργοποιεί την υποστήριξη ήχου για τις ειδοποιήσεις."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Μπάρα κύλισης"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Τυπικό θέμα"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Σφάλμα ενεργοποίησης libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Δοκιμή ειδοποίησης"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Αυτό είναι μια δοκιμή"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Σφάλμα εμφάνισης ειδοποιήσεων: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Αδυναμία φόρτωσης αρχείου περιβάλλοντος χρήσης: %s"

--- a/mate-notification-daemon/po/es.po
+++ b/mate-notification-daemon/po/es.po
@@ -60,32 +60,32 @@ msgstr "El tema usado al mostrar las notificaciones."
 msgid "Turns on and off sound support for notifications."
 msgstr "Activar y desactivar el soporte de sonido para las notificaciones."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Deslizador"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Tema estándar"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Error al iniciar libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Prueba de notificación"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Simplemente una prueba"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Error al mostrar la notificación: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "No se pudo cargar el archivo de interfaz de usuario: %s"

--- a/mate-notification-daemon/po/fr.po
+++ b/mate-notification-daemon/po/fr.po
@@ -60,32 +60,32 @@ msgstr "Le thème utilisé pour l'affichage des notifications."
 msgid "Turns on and off sound support for notifications."
 msgstr "Active ou désactive la prise en charge du son pour les notifications."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Curseur"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Thème standard"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Erreur d'initialisation de libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Test de notification"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Un simple test"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Erreur lors de l'affichage d'une notification : %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Impossible de charger le fichier d'interface utilisateur : %s"

--- a/mate-notification-daemon/po/gl.po
+++ b/mate-notification-daemon/po/gl.po
@@ -58,32 +58,32 @@ msgstr "O tema usado ao mostrar as notificacións."
 msgid "Turns on and off sound support for notifications."
 msgstr "Activar ou desactivar a compatibilidade de son para as notificacións."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Control desprazábel"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Tema estándar"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Produciuse un erro ao inicializar libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Proba de notificación"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Só unha proba"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Produciuse un erro ao mostrar a notificación. %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Non é posíbel cargar o ficheiro de interface do usuario: %s"

--- a/mate-notification-daemon/po/hu.po
+++ b/mate-notification-daemon/po/hu.po
@@ -60,32 +60,32 @@ msgstr "Az értesítések megjelenítéséhez használt téma."
 msgid "Turns on and off sound support for notifications."
 msgstr "Be- illetve kikapcsolja az értesítések hangját."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Csúszka"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Alapértelmezett téma"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Hiba a libmatenotify előkészítése közben"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Értesítésteszt"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Csak egy próba"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Hiba az értesítés megjelenítésekor: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "A felhasználóifelület-fájl nem tölthető be: %s"

--- a/mate-notification-daemon/po/it.po
+++ b/mate-notification-daemon/po/it.po
@@ -57,48 +57,48 @@ msgstr "Il tema usato nel mostrare le notifiche."
 msgid "Turns on and off sound support for notifications."
 msgstr "Attiva e disattiva il supporto audio alle notifiche."
 
-#: ../src/capplet/notification-properties.c:79
+#: ../src/capplet/mate-notification-properties.c:79
 msgid "Top Left"
 msgstr "Alto - sinistra"
 
-#: ../src/capplet/notification-properties.c:80
+#: ../src/capplet/mate-notification-properties.c:80
 msgid "Top Right"
 msgstr "Alto - destra"
 
-#: ../src/capplet/notification-properties.c:81
+#: ../src/capplet/mate-notification-properties.c:81
 msgid "Bottom Left"
 msgstr "Basso - sinistra"
 
-#: ../src/capplet/notification-properties.c:82
+#: ../src/capplet/mate-notification-properties.c:82
 msgid "Bottom Right"
 msgstr "Basso - destra"
 
-#: ../src/capplet/notification-properties.c:327
+#: ../src/capplet/mate-notification-properties.c:327
 msgid "Ubuntu theme"
 msgstr "Tema di Ubuntu"
 
-#: ../src/capplet/notification-properties.c:329
+#: ../src/capplet/mate-notification-properties.c:329
 msgid "Standard theme"
 msgstr "Tema predefinito"
 
-#: ../src/capplet/notification-properties.c:422
+#: ../src/capplet/mate-notification-properties.c:422
 msgid "Error initializing libmatenotify"
 msgstr "Errore nell'inizializzare libmatenotify"
 
-#: ../src/capplet/notification-properties.c:435
+#: ../src/capplet/mate-notification-properties.c:435
 msgid "Notification Test"
 msgstr "Controllo notifica"
 
-#: ../src/capplet/notification-properties.c:436
+#: ../src/capplet/mate-notification-properties.c:436
 msgid "Just a test"
 msgstr "Solo un controllo"
 
-#: ../src/capplet/notification-properties.c:443
+#: ../src/capplet/mate-notification-properties.c:443
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Errore durante la visualizzazione della notifica: %s"
 
-#: ../src/capplet/notification-properties.c:500
+#: ../src/capplet/mate-notification-properties.c:500
 #, c-format
 msgid "Unable to locate glade file '%s'"
 msgstr "Impossibile localizzare il file glade «%s»"

--- a/mate-notification-daemon/po/ja.po
+++ b/mate-notification-daemon/po/ja.po
@@ -56,48 +56,48 @@ msgstr "通知ダイアログを表示する際に使用するテーマです。
 msgid "Turns on and off sound support for notifications."
 msgstr "通知時にサウンドを鳴らすかどうかを指定します。"
 
-#: ../src/capplet/notification-properties.c:79
+#: ../src/capplet/mate-notification-properties.c:79
 msgid "Top Left"
 msgstr "左上隅"
 
-#: ../src/capplet/notification-properties.c:80
+#: ../src/capplet/mate-notification-properties.c:80
 msgid "Top Right"
 msgstr "右上隅"
 
-#: ../src/capplet/notification-properties.c:81
+#: ../src/capplet/mate-notification-properties.c:81
 msgid "Bottom Left"
 msgstr "左下隅"
 
-#: ../src/capplet/notification-properties.c:82
+#: ../src/capplet/mate-notification-properties.c:82
 msgid "Bottom Right"
 msgstr "右下隅"
 
-#: ../src/capplet/notification-properties.c:327
+#: ../src/capplet/mate-notification-properties.c:327
 msgid "Ubuntu theme"
 msgstr "Ubuntu のテーマ"
 
-#: ../src/capplet/notification-properties.c:329
+#: ../src/capplet/mate-notification-properties.c:329
 msgid "Standard theme"
 msgstr "標準のテーマ"
 
-#: ../src/capplet/notification-properties.c:422
+#: ../src/capplet/mate-notification-properties.c:422
 msgid "Error initializing libmatenotify"
 msgstr "libmatenotify の初期化に失敗しました"
 
-#: ../src/capplet/notification-properties.c:435
+#: ../src/capplet/mate-notification-properties.c:435
 msgid "Notification Test"
 msgstr "ポップアップ通知のテスト"
 
-#: ../src/capplet/notification-properties.c:436
+#: ../src/capplet/mate-notification-properties.c:436
 msgid "Just a test"
 msgstr "テスト中です"
 
-#: ../src/capplet/notification-properties.c:443
+#: ../src/capplet/mate-notification-properties.c:443
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "ポップアップ通知に失敗しました: %s"
 
-#: ../src/capplet/notification-properties.c:500
+#: ../src/capplet/mate-notification-properties.c:500
 #, c-format
 msgid "Unable to locate glade file '%s'"
 msgstr ".glade ファイルを特定できません: %s"

--- a/mate-notification-daemon/po/lt.po
+++ b/mate-notification-daemon/po/lt.po
@@ -57,32 +57,32 @@ msgstr "Tema, naudojama rodant pranešimus."
 msgid "Turns on and off sound support for notifications."
 msgstr "Įjungia ir išjungia garso palaikymą pranešimams."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Slankiklis"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Standartinė tema"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Klaida inicializuojant libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Pranešimo testas"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Tik testas"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Klaida rodant pranešimą: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Nepavyko pakrauti sąsajos failo: %s"

--- a/mate-notification-daemon/po/nb.po
+++ b/mate-notification-daemon/po/nb.po
@@ -51,32 +51,32 @@ msgstr "Tema som brukes ved visning av varslinger."
 msgid "Turns on and off sound support for notifications."
 msgstr ""
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr ""
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Standard tema"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Feil under initiering av libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Test av varsling"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Bare en test"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Feil ved visning av varsling: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Kunne ikke laste brukergrensesnittfil: %s"

--- a/mate-notification-daemon/po/pa.po
+++ b/mate-notification-daemon/po/pa.po
@@ -58,32 +58,32 @@ msgstr "ਥੀਮ, ਜੋ ਨੋਟੀਫਿਕੇਸ਼ਨ ਵੇਖਾਉਣ �
 msgid "Turns on and off sound support for notifications."
 msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਲਈ ਸਾਊਂਡ ਸਹਿਯੋਗ ਬੰਦ ਅਤੇ ਚਾਲੂ ਕਰੋ।"
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "ਸਲਾਈਡਰ"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "ਸਟੈਂਡਰਡ ਥੀਮ"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "libmatenotify ਸ਼ੁਰੂ ਕਰਨ ਦੌਰਾਨ ਗਲਤੀ"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਟੈਸਟ"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "ਸਿਰਫ ਟੈਸਟ ਹੈ"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "ਨੋਟੀਫਿਕੇਸ਼ਨ ਵੇਖਾਉਣ ਦੌਰਾਨ ਗਲਤੀ: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "ਯੂਜ਼ਰ ਇੰਟਰਫੇਸ ਫਾਇਲ ਲੋਡ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕੀ: %s"

--- a/mate-notification-daemon/po/pl.po
+++ b/mate-notification-daemon/po/pl.po
@@ -63,32 +63,32 @@ msgstr "Motyw używany podczas wyświetlania powiadomień."
 msgid "Turns on and off sound support for notifications."
 msgstr "Włącza lub wyłącza obsługę dźwięków dla powiadomień."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Slider"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Motyw standardowy"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Błąd podczas inicjowania biblioteki libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Test powiadomienia"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "To tylko test"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Błąd podczas wyświetlania powiadomienia: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Nie można wczytać pliku interfejsu użytkownika: %s"

--- a/mate-notification-daemon/po/pt_BR.po
+++ b/mate-notification-daemon/po/pt_BR.po
@@ -58,32 +58,32 @@ msgstr "O tema usado ao exibir notificações."
 msgid "Turns on and off sound support for notifications."
 msgstr "Liga ou desliga o suporte a som para notificações."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Controle deslizante"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Tema padrão"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Erro ao inicializar libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Teste de notificação"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Somente um teste"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Erro ao exibir notificação: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Não foi possível carregar arquivo de interface: %s"

--- a/mate-notification-daemon/po/ru.po
+++ b/mate-notification-daemon/po/ru.po
@@ -59,32 +59,32 @@ msgstr "Тема, используемая при отображении уве�
 msgid "Turns on and off sound support for notifications."
 msgstr "Включение и выключение поддержки звука в уведомлениях."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Ползунок"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Стандартная тема"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Ошибка инициализации libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Тестовое уведомление"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Обычная проверка"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Ошибка вывода уведомления: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Не удалось загрузить файл пользовательского интерфейса: %s"

--- a/mate-notification-daemon/po/sl.po
+++ b/mate-notification-daemon/po/sl.po
@@ -52,32 +52,32 @@ msgstr "Tema za prikaz obvestil."
 msgid "Turns on and off sound support for notifications."
 msgstr "Vklopi in izklopi zvočno podporo obvestil."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Drsnik"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Običajna tema"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Napaka med zaganjanjem libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Preizkus obvestila"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Samo preizkus"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Napaka med prikazovanjem obvestila: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Ni mogoče naložiti datoteke uporabniškega vmesnika: %s"

--- a/mate-notification-daemon/po/sv.po
+++ b/mate-notification-daemon/po/sv.po
@@ -47,32 +47,32 @@ msgstr "Temat som används för visning av notifieringar."
 msgid "Turns on and off sound support for notifications."
 msgstr "Slår på och av ljudstöd för notifieringar."
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "Draglist"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "Standardtema"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "Fel vid initiering av libmatenotify"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "Notifieringstest"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "Bara ett test"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "Fel vid visning av notifiering: %s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "Kunde inte läsa in användargränssnittsfil: %s"

--- a/mate-notification-daemon/po/zh_CN.po
+++ b/mate-notification-daemon/po/zh_CN.po
@@ -56,32 +56,32 @@ msgstr "显示通知时使用的主题。"
 msgid "Turns on and off sound support for notifications."
 msgstr "为通知打开和关闭声音支持"
 
-#: ../src/capplet/notification-properties.c:293
+#: ../src/capplet/mate-notification-properties.c:293
 msgid "Slider"
 msgstr "滑块"
 
-#: ../src/capplet/notification-properties.c:295
+#: ../src/capplet/mate-notification-properties.c:295
 msgid "Standard theme"
 msgstr "标准主题"
 
-#: ../src/capplet/notification-properties.c:391
+#: ../src/capplet/mate-notification-properties.c:391
 msgid "Error initializing libmatenotify"
 msgstr "初始化 libmatenotify 出错"
 
-#: ../src/capplet/notification-properties.c:403
+#: ../src/capplet/mate-notification-properties.c:403
 msgid "Notification Test"
 msgstr "通知测试"
 
-#: ../src/capplet/notification-properties.c:404
+#: ../src/capplet/mate-notification-properties.c:404
 msgid "Just a test"
 msgstr "仅仅一个测试"
 
-#: ../src/capplet/notification-properties.c:411
+#: ../src/capplet/mate-notification-properties.c:411
 #, c-format
 msgid "Error while displaying notification: %s"
 msgstr "显示通知时出错：%s"
 
-#: ../src/capplet/notification-properties.c:472
+#: ../src/capplet/mate-notification-properties.c:472
 #, c-format
 msgid "Could not load user interface file: %s"
 msgstr "无法加载用户界面文件：%s"


### PR DESCRIPTION
The build requires making notification-properties.c, but that file doesn't exist. Renamed references to mate-notification-properties.
