### PR TITLE
mate-menus POTFILES.in issues

### DIFF
--- a/mate-menus/po/POTFILES.in
+++ b/mate-menus/po/POTFILES.in
@@ -1,13 +1,13 @@
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
-desktop-directories/AudioVideo.directory.in
-desktop-directories/Development.directory.in
-desktop-directories/Education.directory.in
+desktop-directories/mate-audio-video.directory.in
+desktop-directories/mate-development.directory.in
+desktop-directories/mate-education.directory.in
 desktop-directories/mate-game.directory.in
 desktop-directories/mate-graphics.directory.in
 desktop-directories/mate-hardware.directory.in
 desktop-directories/mate-internet-and-network.directory.in
-desktop-directories/mate-lookAndFeel.directory.in
+desktop-directories/mate-look-and-feel.directory.in
 desktop-directories/mate-network.directory.in
 desktop-directories/mate-office.directory.in
 desktop-directories/mate-personal.directory.in


### PR DESCRIPTION
Fixed incorrect files references in POTFILES.in

NOTE: this is not the only issue. POTFILES.in all requires several files in the simple-editor folder which was deleted in a previous commit (linked below). The reasons for these deletions was something along the lines of "gnome 3 conflict". The changes to the simple-editor folder and whatever files were affected by this need to be restored it seems.

commit: https://github.com/Perberos/Mate-Desktop-Environment/commit/858d4227f1c6a95c2c24ecfbbf3cebd5e3280658#mate-menus
