### PR TITLE
some tweaks to the scripts

### DIFF
--- a/README
+++ b/README
@@ -14,7 +14,7 @@
 
   Clone this repository using this command in your terminal
     
-    $ git clone git@github.com:perberos/Mate-Desktop-Environment.git mate --depth=1
+    $ git clone https://github.com/perberos/Mate-Desktop-Environment.git mate --depth=1
   
   When git cloning finish, run the clone-base.sh script
     

--- a/base-clone.sh
+++ b/base-clone.sh
@@ -52,7 +52,7 @@ for i in $(seq 0 $((${#listofpackages[@]} - 1))); do
 	package=${name:`expr index "$repo" /`}
 
 	if [ -d $folder ]; then
-		git clone git@github.com:$repo.git
+		git clone https://github.com/$repo.git
 	else
 		echo Skip $folder.
 	fi

--- a/extra-clone.sh
+++ b/extra-clone.sh
@@ -17,12 +17,12 @@
 
 listofpackages=(
 	mate-desktop/mate-applets
-	mate-desktop/mate-backgrounds
 	mate-desktop/mate-bluetooth
 	mate-desktop/mate-calc
 	mate-desktop/mate-display-manager
 	mate-desktop/mate-document-viewer
 	mate-desktop/mate-file-archiver
+	mate-desktop/mate-file-manager-sendto
 	mate-desktop/mate-image-viewer
 	mate-desktop/mate-power-manager
 	mate-desktop/mate-screensaver

--- a/extra-clone.sh
+++ b/extra-clone.sh
@@ -38,7 +38,7 @@ for i in $(seq 0 $((${#listofpackages[@]} - 1))); do
 	package=${name:`expr index "$repo" /`}
 
 	if [ -d $folder ]; then
-		git clone git@github.com:$repo.git
+		git clone https://github.com/$repo.git
 	else
 		echo Skip $folder.
 	fi

--- a/extra-pull.sh
+++ b/extra-pull.sh
@@ -17,12 +17,12 @@
 
 listofpackages=(
     mate-applets
-    mate-backgrounds
     mate-bluetooth
     mate-calc
     mate-display-manager
     mate-document-viewer
     mate-file-archiver
+    mate-file-manager-sendto
     mate-image-viewer
     mate-power-manager
     mate-screensaver


### PR DESCRIPTION
1) currently the git URLs use git@github.com:$repo.git which only works if you have a github account. for someone who just want to grab and build the code https URLs would be better. Someone who does have a github account can probably work out what to change if they want to checkout with their login.

2) mate-backgrounds was listed in both base and extras. mate-file-manager-sendto was missing from both, but is required for mate-bluetooth, so i added it to extras.

thanks, sam
