### PR TITLE
add libmatewnck

### DIFF
--- a/base-clone.sh
+++ b/base-clone.sh
@@ -25,6 +25,7 @@ listofpackages=(
     mate-desktop/libmatenotify
     mate-desktop/libmateui
     mate-desktop/libmateweather
+    mate-desktop/libmatewnck
     mate-desktop/mate-backgrounds
     mate-desktop/mate-common
     mate-desktop/mate-conf

--- a/base-pull.sh
+++ b/base-pull.sh
@@ -25,6 +25,7 @@ listofpackages=(
     libmatenotify
     libmateui
     libmateweather
+    libmatewnck
     mate-backgrounds
     mate-common
     mate-conf


### PR DESCRIPTION
In mate 1.4 libwnck was forked as libmatewnck.

http://mate-desktop.org/2012/07/30/mate-1-4-released/
